### PR TITLE
config for pygments

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -12,3 +12,5 @@ github_username:  nil
 markdown: kramdown
 kramdown:
   input: GFM
+
+highlighter: pygments


### PR DESCRIPTION
gh-pages で pygments がハイライトされないため明示的に指定してみる。
