### PR TITLE
fix typo

### DIFF
--- a/awards/index.html
+++ b/awards/index.html
@@ -177,7 +177,7 @@ partners:
     img: publickey.png
     url: http://www.publickey1.jp/
 notice:
-  - date: 2016-04-XX
+  - date: 2016-04-13
     title: 縦書きWebデザインアワードの結果を発表しました。
   - date: 2016-02-16
     title: 応募を〆切ました。事前審査の上、候補者には個別にご連絡します。


### PR DESCRIPTION
結果発表日付の表記漏れを補完
